### PR TITLE
Update bootstrap script to specify node version

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,6 +106,7 @@ install_nodejs() {
   source "/usr/local/opt/nvm/nvm.sh"
 
   nvm install "$NODE_VERSION"
+  nvm use "$NODE_VERSION"
 
   nvm alias default "$DEFAULT_NODE_VERSION"
   log "✅ Nodejs installed"


### PR DESCRIPTION
Previously, the bootstrap script would install node, but not specify nvm to use that version of node that was installed. This change fixes that bug.