### PR TITLE
Change bash shell to homebrew-installed path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ As of MacOS Catalina (10.15), `bash` is no longer the default shell. The default
 If you want to continue to use `bash`, change your default shell:
 
 ```sh
-chsh -s /bin/bash
+# Path to current bash binary installed with homebrew by bootstrap.sh
+chsh -s /usr/local/bin/bash
 ```
 
-After this, close and reopen Terminal. It will be running `bash` as the default shell.
+After this, close and reopen Terminal. It will be running `bash` as the default shell. For more info see [HT208050](https://support.apple.com/en-us/HT208050).
 
 ## References
 


### PR DESCRIPTION
I personally use the homebrew installed bash as my default shell (`/usr/local/bin/bash`). People who choose bash as their default shell should probably use this version day-to-day as opposed to `/bin/bash` released in 2007 😮 

PS, fun log of changes since then - everything from line 3628 up LOL: http://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?h=bash-5.0#n3628