### PR TITLE
Install helm3 for the adventurous

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -207,7 +207,19 @@ pin_helm() {
 initialize_helm() {
   helm init --client-only
   mkdir -p "$(helm home)/plugins"
-  helm plugin install https://github.com/databus23/helm-diff --version master || true
+  helm plugin install https://github.com/databus23/helm-diff --version master 2>/dev/null || true
+}
+
+# Until we fully adopt Helm v3, install 'helm3' (v3) alongside 'helm' (v2).
+# Once v3.0.0 is released, the Homebrew formula will be updated and we can
+# unpin when we're ready.
+install_helm3() {
+  local helm_version=v3.0.0-rc.3
+  curl -sSLO "https://get.helm.sh/helm-$helm_version-darwin-amd64.tar.gz"
+  sudo mkdir -p "/usr/local/helm-$helm_version"
+  sudo tar -xzf "helm-$helm_version-darwin-amd64.tar.gz" -C "/usr/local/helm-$helm_version"
+  sudo ln -sf "/usr/local/helm-$helm_version/darwin-amd64/helm" /usr/local/bin/helm3
+  rm "helm-$helm_version-darwin-amd64.tar.gz"
 }
 
 log "⚠️  Beginning Bootstrap"
@@ -223,5 +235,6 @@ configure_ssh
 k8s_completion
 pin_helm
 initialize_helm
+install_helm3
 
 log "✅ Bootstrap Complete 🚀🚀🚀"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -220,6 +220,14 @@ install_helm3() {
   sudo tar -xzf "helm-$helm_version-darwin-amd64.tar.gz" -C "/usr/local/helm-$helm_version"
   sudo ln -sf "/usr/local/helm-$helm_version/darwin-amd64/helm" /usr/local/bin/helm3
   rm "helm-$helm_version-darwin-amd64.tar.gz"
+
+  # helm3 plugins
+  if ! helm3 plugin update diff 2>/dev/null; then
+    helm3 plugin install https://github.com/databus23/helm-diff
+  fi
+  if ! helm3 plugin update namespace 2>/dev/null; then
+    helm3 plugin install https://github.com/thomastaylor312/helm-namespace
+  fi
 }
 
 log "⚠️  Beginning Bootstrap"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -214,7 +214,7 @@ initialize_helm() {
 # Once v3.0.0 is released, the Homebrew formula will be updated and we can
 # unpin when we're ready.
 install_helm3() {
-  local helm_version=v3.0.0-rc.3
+  helm_version=v3.0.0-rc.3
   curl -sSLO "https://get.helm.sh/helm-$helm_version-darwin-amd64.tar.gz"
   sudo mkdir -p "/usr/local/helm-$helm_version"
   sudo tar -xzf "helm-$helm_version-darwin-amd64.tar.gz" -C "/usr/local/helm-$helm_version"


### PR DESCRIPTION
Will keep this up to date. Helm `v3.0.0-rc.3` was released an hour ago

After running bootstrap script, test version
```console
$ helm3 version -c
version.BuildInfo{Version:"v3.0.0-rc.3", GitCommit:"2ed206799b451830c68bff30af2a52879b8b937a", GitTreeState:"clean", GoVersion:"go1.13.4"}
```