### PR TITLE
DEVOPS-1578 add aws session-manager-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Bootstrap your laptop into a lean, mean, software-shipping dev machine.
   ```sh
   xcode-select --install
   ```
-* Bash
+* Bash or Zsh
 
-  The bootstrap script assumes you use bash and adds some required code to `~/.bash_profile`.
+  The bootstrap script assumes you use bash or zsh and adds required configuration to `~/.bash_profile` and `~/.zshrc` respectively.
   If using another shell, e.g. zsh, you'll need to accommodate that yourself.
 
 ## Usage

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -81,6 +81,8 @@ brew "shellcheck"
 brew "awscli"
 # https://github.com/99designs/aws-vault
 cask "aws-vault"
+# Session Manager Plugin for the AWS CLI
+cask "session-manager-plugin"
 # Package for GNU standards-compliant Makefiles
 brew "automake"
 # GNU generic library support script


### PR DESCRIPTION
There's a homebrew cask now which simplifies this: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/session-manager-plugin.rb

ie, we dont have to follow the manual steps [here](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#install-plugin-macos)