### PR TITLE
DEVOPS-1671 install awscli@1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,6 +87,10 @@ brew_bundle() {
   log "⚠️  Installing homebrew packages from Brewfile"
   brew update && \
     brew bundle --file=./files/Brewfile
+
+  # add "keg-only" formulae to the path, e.g see `brew info awscli@1`
+  append_to_dotfiles 'export PATH="/usr/local/opt/awscli@1/bin:$PATH"'
+
   log "✅ Homebrew packages up to date"
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -89,6 +89,7 @@ brew_bundle() {
     brew bundle --file=./files/Brewfile
 
   # add "keg-only" formulae to the path, e.g see `brew info awscli@1`
+  # shellcheck disable=SC2016
   append_to_dotfiles 'export PATH="/usr/local/opt/awscli@1/bin:$PATH"'
 
   log "✅ Homebrew packages up to date"

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -78,7 +78,7 @@ brew "postgresql"
 # Static analysis and lint tool, for (ba)sh scripts
 brew "shellcheck"
 # Official Amazon AWS command-line interface
-brew "awscli"
+brew "awscli@1"
 # https://github.com/99designs/aws-vault
 cask "aws-vault"
 # Session Manager Plugin for the AWS CLI


### PR DESCRIPTION
`awscli` v2 was recently released, which has some breaking changes: See [aws upgrade guide](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html).

Eventually we should upgrade to v2, but we need to update our docs and workflows to be compatible. **Until then, this PR ensures awscli v1 is installed.**