### PR TITLE
DEVOPS-2432 pin terraform version

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,8 @@ YARN_VERSION="1.21.1"
 SSH_KEY="$HOME/.ssh/id_rsa"
 SSH_CONFIG="$HOME/.ssh/config"
 
+TERRAFORM_VERSION="0.13.4"
+
 ####################
 # Helpers          #
 ####################
@@ -217,6 +219,12 @@ initialize_helm() {
   helm plugin install https://github.com/databus23/helm-diff --version master || true
 }
 
+# Use tfenv to manage terraform versions.
+install_terraform() {
+  tfenv install "$TERRAFORM_VERSION"
+  tfenv use "$TERRAFORM_VERSION"
+}
+
 log "⚠️  Beginning Bootstrap"
 
 install_homebrew
@@ -230,6 +238,7 @@ configure_ssh
 k8s_completion
 pin_helm
 initialize_helm
+install_terraform
 
 log "✅ Bootstrap Complete 🚀🚀🚀"
 log "👉 Restart your terminal window to enjoy your bootstrapped goodness. 👈"

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -92,8 +92,8 @@ brew "libtool"
 # Manipulates uploaded images
 brew "imagemagick"
 
-# Tool to build, change, and version infrastructure
-brew "terraform"
+#Terraform version manager inspired by rbenv
+brew "tfenv"
 
 # High-performance, schema-free, document-oriented database
 brew "mongodb/brew/mongodb-community@3.6"


### PR DESCRIPTION
Use [`tfenv`](https://github.com/tfutils/tfenv) to manage terraform versions.

- For new setups this should simply work out of the box
- For existing setups where `terraform` is already installed, rerun the bootstrap, or just run:
   ```sh
   brew install tfenv
   tfenv install 0.13.4
   tfenv use 0.13.4
   ```
  - **NOTE:** you MAY `brew uninstall terraform`, but you don't need to, as the `tfenv` symlinks will override the direct terraform ones.

