### PR TITLE
linux_bootstrap: Add task to ensure directory used for binaries exists

### DIFF
--- a/ansible/linux_bootstrap.yml
+++ b/ansible/linux_bootstrap.yml
@@ -63,6 +63,10 @@
           debug:
             var: result
 
+        - name: ensure the ~/bin dir exists
+          script:
+            cmd: /usr/bin/mkdir ~/bin
+
         - name: Install helmfile in ~/bin
           get_url:
             url: https://github.com/roboll/helmfile/releases/download/v0.129.3/helmfile_linux_amd64


### PR DESCRIPTION
Just ran this on Fedora 33 and this was the only real problem I encountered!

Maybe, someday, I can add fish shell setup, too! :fish: 

Thank you so much whoever set up the fedora stuff.