### PR TITLE
Install yarn

### DIFF
--- a/ansible/fedora.yml
+++ b/ansible/fedora.yml
@@ -28,6 +28,7 @@
     - ruby
     - ShellCheck
     - which
+    - yarn
     - zlib-devel
     state: present
   become: yes

--- a/ansible/linux_bootstrap.yml
+++ b/ansible/linux_bootstrap.yml
@@ -65,7 +65,7 @@
 
         - name: ensure the ~/bin dir exists
           script:
-            cmd: /usr/bin/mkdir ~/bin
+            cmd: /usr/bin/mkdir -p ~/bin
 
         - name: Install helmfile in ~/bin
           get_url:

--- a/ansible/yum_repos.yml
+++ b/ansible/yum_repos.yml
@@ -24,3 +24,15 @@
             gpgkey: https://www.mongodb.org/static/pgp/server-4.4.asc
             repo_gpgcheck: yes
             state: present
+
+
+        - name: Install Yarn yum_repository
+          yum_repository:
+            name: yarn
+            baseurl: https://dl.yarnpkg.com/rpm/
+            description: "Yarn Repository"
+            enabled: yes
+            gpgcheck: yes
+            gpgkey: https://dl.yarnpkg.com/rpm/pubkey.gpg
+            repo_gpgcheck: yes
+            state: present


### PR DESCRIPTION
I had to install yarn to get `envs` working, since it needs its own repo, too, figured this would be a good place to add it.  Also changed the `mkdir ~/bin` task to not complain when the directory already exists!