### PR TITLE
DEVOPS-2494 upgrade helm

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -60,7 +60,7 @@ append_to_dotfile() {
 # Beware of various stackoverflow/exchange answers referencing the deprecated
 # Homebrew/versions repository (notably https://stackoverflow.com/a/4158763).
 # However that post has a good info on how to find the SHA you need 📄
-pin_forumla() {
+pin_formula() {
   formula="$1"
   version="$2"
   sha="$3"
@@ -205,18 +205,8 @@ k8s_completion() {
   append_to_dotfiles 'complete -F __start_kubectl k'
 }
 
-# Temporary shim to address https://codecademy.atlassian.net/browse/DEVOPS-1235
-# To-do: Remove this function in favor of Brewfile once Helm v3 is GA and in
-#   homebrew. ETA planning a 3.0 GA release before KubeCon San Diego
-#   Nov/18/2019.
-pin_helm() {
-  pin_forumla kubernetes-helm 2.14.3 0a17b8e50963de12e8ab3de22e53fccddbe8a226
-}
-
-initialize_helm() {
-  helm init --client-only
-  mkdir -p "$(helm home)/plugins"
-  helm plugin install https://github.com/databus23/helm-diff --version master || true
+install_helm_plugins() {
+  helm plugin install https://github.com/databus23/helm-diff
 }
 
 # Use tfenv to manage terraform versions.
@@ -236,8 +226,7 @@ git_config
 create_ssh_key
 configure_ssh
 k8s_completion
-pin_helm
-initialize_helm
+install_helm_plugins
 install_terraform
 
 log "✅ Bootstrap Complete 🚀🚀🚀"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -216,7 +216,7 @@ if [ "$#" -eq "0" ]; then
   install_terraform
 else
   # run only the specified command, e.g. ./bootstrap.sh brew_bundle
-  $@
+  "$@"
 fi
 
 log "✅ Bootstrap Complete 🚀🚀🚀"

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -50,9 +50,9 @@ cask "docker"
 # Kubernetes command-line interface
 brew "kubernetes-cli"
 # Kubernetes package manager
-brew "helm"
+brew "codecademy-engineering/bootstrap/helm@3.3.4"
 # Deploy Kubernetes Helm Charts
-brew "helmfile"
+brew "codecademy-engineering/bootstrap/helmfile@0.132.1"
 # Tool that can switch between kubectl contexts easily and create aliases
 brew "kubectx"
 # Kubernetes cluster creator/maintainer

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -49,9 +49,8 @@ cask "docker"
 
 # Kubernetes command-line interface
 brew "kubernetes-cli"
-# The Kubernetes package manager
-# To-do: See pin_helm() in bootstrap.sh.
-# brew "kubernetes-helm"
+# Kubernetes package manager
+brew "helm"
 # Deploy Kubernetes Helm Charts
 brew "helmfile"
 # Tool that can switch between kubectl contexts easily and create aliases


### PR DESCRIPTION
So previously we had a way to install exact versions of Homebrew formula with this:
https://github.com/codecademy-engineering/bootstrap/blob/55d8510509ef4d973e5b492e7ab1ecf15c1cf20c/bootstrap.sh#L55-L72

Unfortunately the core of that, installing a formua from a raw github url, is no longer supported, e.g.:

```
brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/eb4526dc4ad26437c14d854912aa989316dfce69/Formula/helm.rb

Error: Calling Installation of helm from a GitHub commit URL is disabled! Use 'brew extract helm' to stable tap on GitHub instead.
```

There's a contentious argument about this on GH: https://github.com/Homebrew/brew/issues/8791

But ultimately Homebrew has a certain philosophy about supporting specific versions of things in the `homebrew/core` tap, so **if we want to control versions, we need to manage our own tap**.

So, here is our tap, which has the versions of `helm` and `helmfile` we need: https://github.com/codecademy-engineering/homebrew-bootstrap

And this PR updates the bootstrap to use formulae in that tap.
