### PR TITLE
fix ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: "shellcheck bootstrap.sh"
   run:
     macos:
-      xcode: "11.0"
+      xcode: "12.1"
     steps:
       - checkout
       - run:
@@ -18,6 +18,8 @@ jobs:
           command: "./bootstrap.sh | tee -a bootstrap.log"
       - store_artifacts:
           path: ./bootstrap.log
+      - store_artifacts:
+          path: ./files/Brewfile.lock.json
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.log
 *.env
+
+# See https://github.com/Homebrew/homebrew-bundle/pull/552
+# This isn't a "proper" lockfile, but rather just a way to record a successful `brew bundle`
+files/Brewfile.lock.json

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,7 +105,7 @@ install_ruby() {
   rbenv versions
 
   # shellcheck disable=SC2016
-  append_to_dotfiles "eval \"\$(rbenv init -)\""
+  append_to_dotfiles 'eval "$(rbenv init -)"'
 
   log "✅ Ruby installed"
 }

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -3,6 +3,7 @@ tap "homebrew/cask"
 tap "homebrew/core"
 tap "homebrew/services"
 tap "mongodb/brew"
+tap "codecademy-engineering/bootstrap"
 
 ##########
 # Ruby


### PR DESCRIPTION
The build was failing yesterday after adding our third party tap and formulae: https://app.circleci.com/pipelines/github/codecademy-engineering/bootstrap/115/workflows/fca4634c-e55d-46fc-846c-ed1447fd4e3a/jobs/148

Seems the CircleCI macOS executor had an older version of Homebrew (2.1.11), which was failing to install some of the Brewfile dependencies.

This PR updates to the latest [CircleCI MacOS xcode version](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions), which also includes the current Homebrew version (2.5.6).