### PR TITLE
DEVOPS-2504 install gnu cli tools

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,16 +70,18 @@ install_homebrew() {
   fi
 }
 
+# shellcheck disable=SC2016
 brew_bundle() {
   log "⚠️  Installing homebrew packages from Brewfile"
   brew update && \
     brew bundle --file=./files/Brewfile
 
-  # add "keg-only" formulae to the path, e.g see `brew info awscli@1`
-  # shellcheck disable=SC2016
   append_to_dotfiles 'export PATH="/usr/local/opt/awscli@1/bin:$PATH"'
-  # shellcheck disable=SC2016
   append_to_dotfiles 'export PATH="/usr/local/opt/mongodb-community@3.6/bin:$PATH"'
+  append_to_dotfiles 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"'
+  append_to_dotfiles 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"'
+  append_to_dotfiles 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"'
+  append_to_dotfiles 'export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"'
 
   log "✅ Homebrew packages up to date"
 }

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -88,11 +88,18 @@ cask "session-manager-plugin"
 brew "automake"
 # GNU generic library support script
 brew "libtool"
-
+# GNU File, Shell, and Text utilities
+brew "coreutils"
+# GNU implementation of the famous stream editor
+brew "gnu-sed"
+# GNU grep, egrep and fgrep
+brew "grep"
+# Collection of GNU find, xargs, and locate
+brew "findutils"
 # Manipulates uploaded images
 brew "imagemagick"
 
-#Terraform version manager inspired by rbenv
+# Terraform version manager inspired by rbenv
 brew "tfenv"
 
 # High-performance, schema-free, document-oriented database


### PR DESCRIPTION
macOS comes with FreeBSD versions of a lot of common command line utilities; however the GNU versions are more up-to-date and more compatible with cross-platform (i.e. Linux) scripts.

Homebrew installs these with a "Caveat", such as:
```
==> Caveats
Commands also provided by macOS have been installed with the prefix "g".
If you need to use these commands with their normal names, you
can add a "gnubin" directory to your PATH from your bashrc like:
  PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
```
so we have to modify the $PATH in order to use them by-default.