### PR TITLE
upgrade to mongo4

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -77,7 +77,7 @@ brew_bundle() {
     brew bundle --file=./files/Brewfile
 
   append_to_dotfiles 'export PATH="/usr/local/opt/awscli@1/bin:$PATH"'
-  append_to_dotfiles 'export PATH="/usr/local/opt/mongodb-community@3.6/bin:$PATH"'
+  append_to_dotfiles 'export PATH="/usr/local/opt/mongodb-community@4.0/bin:$PATH"'
   append_to_dotfiles 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"'
   append_to_dotfiles 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"'
   append_to_dotfiles 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"'

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -103,4 +103,4 @@ brew "imagemagick"
 brew "tfenv"
 
 # High-performance, schema-free, document-oriented database
-brew "mongodb/brew/mongodb-community@3.6"
+brew "mongodb/brew/mongodb-community@4.0"


### PR DESCRIPTION
Upgrade instructions without running the whole bootstrap:
```
brew install mongodb/brew/mongodb-community@4.0

echo 'export PATH="/usr/local/opt/mongodb-community@4.0/bin:$PATH"' >> ~/.zshrc
```