### PR TITLE
Remove kops install; default helm is now helm3; update README

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -47,15 +47,10 @@ but do not run the `firewall-cmd` commands to whitelist Docker as I had trouble 
 * We install both Helm v2.14.3 and Helm v3.3.4 (both hardcoded at that version currently) separately for support of some of our older apps using Helm 2.
 * The version of helm-diff is currently hardcoded to install v2.11.0+5.
 
-## Terraform
+## Manage Terraform versions with tfenv
 
-We install tfenv to manage terraform versions for you, but do not configure any version initially. After this is
-installed you will want to run the following to get your versions setup as you wish:
+Because Terraform versions often have backward incompatible format changes, and we're stuck in between two versions for
+our Terraform code currently, we install `tfenv` to help manage the Terraform versions on your system.
 
-```
-tfenv install          # This will install the most recent terraform version
-tfenv use 0.13.4       # This will tell tfenv to use the most recent version
-tfenv install 0.12.29  # This will install an earlier 'major' version of terraform
-```
-
-You can switch back and forth between the two now, using `tfenv use XXX`.
+We install Terraform minor versions `0.12` and `0.13`. You can switch back and forth between the two with the command:
+`tfenv use XXX`.

--- a/ansible/linux_bootstrap.yml
+++ b/ansible/linux_bootstrap.yml
@@ -73,18 +73,6 @@
             dest: "~/bin/helmfile"
             mode: 0764
 
-        - name: Check kops exists in ~/bin
-          stat: path=~/bin/kops
-          register: kops
-
-        - name: Install kops to ~/bin
-          shell: |
-            curl -LO https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
-            chmod +x kops-linux-amd64
-            mv kops-linux-amd64 ~/bin/kops
-          when: not kops.stat.exists
-          register: result
-
         - name: Show debug output
           debug:
             var: result
@@ -159,37 +147,38 @@
           debug:
             var: result
 
-        - name: Check helm exists in ~/bin
-          stat: path=~/bin/helm
-          register: helm
+        - name: Check helm2 exists in ~/bin
+          stat: path=~/bin/helm2
+          register: helm2
 
         - name: Install helm v{{ HELM2_VERSION }} to ~/bin
           shell: |
             curl "https://get.helm.sh/helm-v{{ HELM2_VERSION }}-linux-amd64.tar.gz" -o helm-v{{ HELM2_VERSION }}-linux-amd64.tar.gz
             tar xzvf helm-v{{ HELM2_VERSION }}-linux-amd64.tar.gz
-            mv linux-amd64/helm ~/bin
+            mv linux-amd64/helm ~/bin/helm2
             mv linux-amd64/tiller ~/bin
             rm helm-v{{ HELM2_VERSION }}-linux-amd64.tar.gz
             rm -rf linux-amd64/
-          when: not helm.stat.exists
+          when: not helm2.stat.exists
           register: result
 
         - name: Show debug output
           debug:
             var: result
 
-        - name: Check helm3 exists in ~/bin
-          stat: path=~/bin/helm3
-          register: helm3
+        - name: Check helm exists in ~/bin
+          stat: path=~/bin/helm
+          register: helm
 
         - name: Install helm v{{ HELM3_VERSION }} to ~/bin
           shell: |
             curl "https://get.helm.sh/helm-v{{ HELM3_VERSION }}-linux-amd64.tar.gz" -o helm-v{{ HELM3_VERSION }}-linux-amd64.tar.gz
             tar xzvf helm-v{{ HELM3_VERSION }}-linux-amd64.tar.gz
             mv linux-amd64/helm ~/bin/helm3
+            ln -rs ~/bin/helm3 ~/bin/helm
             rm helm-v{{ HELM3_VERSION }}-linux-amd64.tar.gz
             rm -rf linux-amd64/
-          when: not helm3.stat.exists
+          when: not helm.stat.exists
           register: result
 
         - name: Show debug output

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -56,8 +56,6 @@ brew "codecademy-engineering/bootstrap/helm@3.3.4"
 brew "codecademy-engineering/bootstrap/helmfile@0.132.1"
 # Tool that can switch between kubectl contexts easily and create aliases
 brew "kubectx"
-# Kubernetes cluster creator/maintainer
-brew "kops"
 
 ##########
 # Misc


### PR DESCRIPTION
Kops is no longer necessary

Helm2 is deprecated, make helm3 default `helm` command
