### PR TITLE
remove go dep

### DIFF
--- a/ansible/fedora.yml
+++ b/ansible/fedora.yml
@@ -11,7 +11,6 @@
     - automake
     - bash-completion
     - curl
-    - dep
     - fzf
     - git
     - gnupg2

--- a/files/Brewfile
+++ b/files/Brewfile
@@ -27,8 +27,6 @@ brew "nvm"
 
 # Open source programming language to build simple/reliable/efficient software
 brew "go"
-# Go dependency management tool
-brew "dep"
 
 ##########
 # Python3


### PR DESCRIPTION
☠ RIP dep 

> Dep was an official experiment to implement a package manager for Go. As of 2020, Dep is deprecated and archived in favor of Go modules
> - https://golang.github.io/dep/docs/introduction.html
 
I don't believe we actually use it anymore anyway...
