### PR TITLE
Swap deprecated Ruby Homebrew installer with Bash

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,7 @@ install_homebrew() {
     log "✅ homebrew is already installed"
   else
     log "⚠️  Installing homebrew"
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     log "✅ homebrew installed"
   fi
 }


### PR DESCRIPTION
```bash
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```
Closes #38 