### PR TITLE
[DEVOPS-2972] Add Detect Secrets action

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,31 @@
+name: Scan Code for Secrets
+'on':
+  push:
+    branches:
+      - '**'
+    tags:
+      - '!**'
+jobs:
+  detect-secrets:
+    name: check-for-secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            detect-secrets
+      - name: Run Yelp's detect-secrets
+        run: >
+          detect-secrets scan --exclude-lines "secretName:" --exclude-secrets
+          "abc123xyz456" > ./.secrets.baseline
+
+          detect-secrets audit ./.secrets.baseline
+      - name: Commit back .secrets.baseline (if it was missing)
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: >-
+            build(detect-secrets): Commit the newly-generated .secrets.baseline
+            file

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,115 @@
+{
+  "version": "1.1.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_line",
+      "pattern": [
+        "secretName:"
+      ]
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "abc123xyz456"
+      ]
+    }
+  ],
+  "results": {},
+  "generated_at": "2021-05-04T17:02:59Z"
+}


### PR DESCRIPTION
This an automated PR that aims to add a [Yelp's Detect Secrets](https://github.com/Yelp/detect-secrets) action.

> `detect-secrets` is an aptly named module for (surprise, surprise) detecting secrets within a code base.

This Pull Request will do the following:

* Add the `.github/workflows/detect-secrets.yml` file
* Run a secret detection analysis on the repo.
* If no issues were found, this PR will also add a `.secrets.baseline` file for subsequent runs.
* If real secrets are found, these should be rotated and removed from the repository.
* For any test/fake secrets you may use command line [filters](https://github.com/Yelp/detect-secrets#filters) or [inline allowlisting](https://github.com/Yelp/detect-secrets#inline-allowlisting) such as:

```
secret = "hunter2"      # pragma: allowlist secret
```

or

```
//  pragma: allowlist nextline secret
const secret = "hunter2";
```