### PR TITLE
[DEVOPS-2984] Custom email detection

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -12,13 +12,41 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v1
       - uses: BSFishy/pip-action@v1
         with:
-          packages: |
-            detect-secrets
-      - name: Run Yelp's detect-secrets
+          packages: detect-secrets
+      - id: detect_secrets_path
+        name: Get the location of the detect-secrets package
         run: |
-          detect-secrets-hook --baseline .secrets.baseline $(git diff origin/main --name-only)
+          _PATH=$(pip show detect-secrets | grep Location | cut -d' ' -f2)
+          echo "::set-output name=value::$_PATH/detect_secrets"
+      - name: Add the email detection plugin
+        run: >
+          echo -e "
+
+          import re
+
+          from detect_secrets.plugins.base import RegexBasedDetector
+
+          class EmailAddressDetector(RegexBasedDetector):
+            secret_type = 'Email'
+            denylist = [
+              re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z.]{2,}')
+            ]
+          " > ${{ steps.detect_secrets_path.outputs.value
+          }}/plugins/email_address.py
+      - name: Run Yelp's detect-secrets (scan)
+        run: |-
+          detect-secrets scan \
+           --exclude-files ".github/workflows/detect-secrets.yml" \
+           --exclude-lines "@codecademy.com" --exclude-lines "NPM_TOKEN" \
+           --exclude-lines "secretName:" \
+           --exclude-secrets "abc123xyz456" \
+           --exclude-secrets "git@github.com" \
+           --exclude-secrets "eks-codecademy-com-prod-api-tls" > ./.secrets.baseline
+      - name: Run Yelp's detect-secrets (audit)
+        run: detect-secrets audit ./.secrets.baseline
+      - name: Audit Report
+        if: failure()
+        run: detect-secrets audit --report ./.secrets.baseline


### PR DESCRIPTION
This an automated PR that aims to add a [Yelp's Detect Secrets](https://github.com/Yelp/detect-secrets) action.

> `detect-secrets` is an aptly named module for (surprise, surprise) detecting secrets within a code base.

This Pull Request will do the following:

* Update the `.github/workflows/detect-secrets.yml` file
* Run an email detection analysis on the repo.
* If sensitive emails are found, these soulds be reported and NOT deleted for now.
* For any test/fake emails you may use command line [filters](https://github.com/Yelp/detect-secrets#filters) or [inline allowlisting](https://github.com/Yelp/detect-secrets#inline-allowlisting) such as:

```
email = "test@example.com"      # pragma: allowlist secret
```

or

```
//  pragma: allowlist nextline secret
const email = "test@example.com";
```