### PR TITLE
DEVOPS-3312 update circleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,17 @@ jobs:
           command: "shellcheck bootstrap.sh"
   run:
     macos:
-      xcode: "12.1"
+      xcode: "12.5.1"
     steps:
       - checkout
       - run:
           name: "Run bootstrap.sh"
-          command: "./bootstrap.sh | tee -a bootstrap.log"
+          command: |
+            # CircleCI's Mac executor comes pre-installed with this `six` python package
+            # which conflicts with the bootstrap... uninstall first
+            pip3 uninstall --yes six
+            # run bootstrap
+            ./bootstrap.sh | tee -a bootstrap.log
       - store_artifacts:
           path: ./bootstrap.log
       - store_artifacts:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -86,8 +86,11 @@ brew_bundle() {
 }
 
 launch_docker() {
-  log "⚠️  Launching Docker"
-  open /Applications/Docker.app
+  # skip on circleci
+  if [ -z "${CIRCLECI:-""}" ]; then
+    log "⚠️  Launching Docker"
+    open /Applications/Docker.app
+  fi
 }
 
 install_ruby() {


### PR DESCRIPTION

There were two issues:
1. The CircleCI MacOS executor comes pre-installed with a python package called `six`, which conflicts with homebrew installation of `awscli`, which also tries to install `six`. This must be a new issue from the latest awscli or Python, which is why the failures are new. 
2. It seems launching Docker causes the script to pause, leaving it without output for > 10 min (see https://app.circleci.com/pipelines/github/codecademy-engineering/bootstrap/177/workflows/bba8cea0-ebe8-4606-a87b-46282dcc74b6/jobs/241)

See example of fixed CI run: https://app.circleci.com/pipelines/github/codecademy-engineering/bootstrap/178/workflows/8351e409-947b-489b-9991-6d2db8333fc3/jobs/243
